### PR TITLE
Preserve fragments in URLs

### DIFF
--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -27,7 +27,9 @@
 (defn- set-retrieve-token! [t]
   (set! (.. t -retrieveToken)
         (fn [path-prefix location]
-          (str (.-pathname location) (.-search location))))
+          (str (.-pathname location)
+               (.-search location)
+               (.-hash location))))
   t)
 
 (defn- set-create-url! [t]
@@ -57,9 +59,11 @@
 
 (defn- get-token-from-uri [uri]
   (let [path (.getPath uri)
-        query (.getQuery uri)]
-    ;; Include query string in token
-    (if (empty? query) path (str path "?" query))))
+        query (.getQuery uri)
+        fragment (.getFragment uri)]
+    (cond-> path
+      (seq query) (str "?" query)
+      (seq fragment) (str "#" fragment))))
 
 (defn pushy
   "Takes in three functions:


### PR DESCRIPTION
When URLs have fragments in them, pushy used to discard them. This change
preserves the fragment. Example:

    <a href="/a-page#some-header">

Pushy would go to just "/a-page" before this change.