### PR TITLE
Find links in area tags

### DIFF
--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -58,6 +58,10 @@
       (seq query) (str "?" query)
       (seq fragment) (str "#" fragment))))
 
+(defn- valid-link? [el]
+  (and (some #(= (.-tagName el) %) ["A" "AREA"])
+       (.hasAttribute el "href")))
+
 (defn pushy
   "Takes in three functions:
     * dispatch-fn: the function that dispatches when a match is found
@@ -102,7 +106,7 @@
         (swap! event-keys conj
                (on-click
                 (fn [e]
-                  (when-let [el (some-> e .-target (dom/getAncestorByTagNameAndClass "a" nil nil))]
+                  (when-let [el (some-> e .-target (dom/getAncestor valid-link? true))]
                     (let [uri (.parse Uri (.-href el))]
                       ;; Proceed if `identity-fn` returns a value and
                       ;; the user did not trigger the event via one of the

--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -59,7 +59,7 @@
       (seq fragment) (str "#" fragment))))
 
 (defn- valid-link? [el]
-  (and (some #(= (.-tagName el) %) ["A" "AREA"])
+  (and (#{"A" "AREA"} (.-tagName el))
        (.hasAttribute el "href")))
 
 (defn pushy


### PR DESCRIPTION
Area tags can contain `href` attributes and serve as valid links: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area

Pushy shouldn't require every link to be in an `a` tag. Other valid tags could be added to the `valid-link?` function if needed.